### PR TITLE
Add build step with babel transpiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 node_modules
 npm-debug.log
 
+lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ before_script:
 
 script:
   - npm install
+  - npm run build
   - npm run test

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
         singleRun: false,
         browserify: {
             debug: true,
-            transform: [["babelify", { stage: 0 }]]
+            transform: [["babelify", {"stage": 0}]]
         }
 
     });

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "mocktail",
   "version": "0.3.3",
   "description": "Mock all of your ES6 module components with Mocktail using dependency injection.",
-  "main": "component/mocktail.js",
+  "main": "lib/mocktail.js",
   "scripts": {
-    "test": "gulp test"
+    "build": "babel --presets=es2015 component -d lib",
+    "test": "gulp test",
+    "clean": "rimraf lib"
   },
   "repository": {
     "type": "git",
@@ -25,6 +27,9 @@
   },
   "homepage": "https://github.com/Wildhoney/Mocktail#readme",
   "devDependencies": {
+    "babel": "^6.0.15",
+    "babel-cli": "^6.0.15",
+    "babel-preset-es2015": "^6.0.15",
     "babelify": "^6.1.3",
     "browserify": "^11.0.1",
     "gulp": "^3.9.0",
@@ -36,6 +41,7 @@
     "karma-browserify": "^4.3.0",
     "karma-firefox-launcher": "^0.1.6",
     "karma-jasmine": "^0.3.6",
-    "karma-spec-reporter": "0.0.20"
+    "karma-spec-reporter": "0.0.20",
+    "rimraf": "^2.4.3"
   }
 }


### PR DESCRIPTION
Transpile es6 code to es5 using babel to allow support for es6
transpiled modules.

Context: Ran into issues running babel-node for tests when importing
this module in it's current state. Could probably set up some
configuration to get it working, but thought I'd update this module to
decrease the barrier to entry for others wanting to use it.
